### PR TITLE
Set client version string for fetch_game_record

### DIFF
--- a/example.py
+++ b/example.py
@@ -128,6 +128,7 @@ async def load_and_process_game_log(lobby, uuid):
 
     req = pb.ReqGameRecord()
     req.game_uuid = uuid
+    req.client_version_string = 'web-0.9.205'
     res = await lobby.fetch_game_record(req)
 
     record_wrapper = pb.Wrapper()


### PR DESCRIPTION
Calls to fetch_game_record needs client_version_string specified as well after the latest MJS API changes.